### PR TITLE
Fixes construction of get commands so that they no longer fail

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -50,7 +50,7 @@ get.sync = function (namespace, options) {
 function _getCommand(location) {
     var cmd = 'git config --list';
     if (location) {
-        cmd += ('--' + location);
+        cmd += (' --' + location);
     }
     return cmd;
 }


### PR DESCRIPTION
The original code constructs a git config command without spaces, causing the flags to be smooshed together. All I did was add a space to the front of the location flag and voila! :-)
