### PR TITLE
Add support fot dot notation

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -50,7 +50,7 @@ get.sync = function (namespace, options) {
 function _getCommand(location) {
     var cmd = 'git config --list';
     if (location) {
-        cmd += ('--' + location);
+        cmd += (' --' + location);
     }
     return cmd;
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -55,7 +55,6 @@ function _getCommand(location) {
     return cmd;
 }
 function _parseStdout(stdout, namespace) {
-    console.log('Parsing stdout')
     var config = {};
     String(stdout).split(os.EOL).forEach(function (line) {
         if (!line) {

--- a/lib/get.js
+++ b/lib/get.js
@@ -55,6 +55,7 @@ function _getCommand(location) {
     return cmd;
 }
 function _parseStdout(stdout, namespace) {
+    console.log('Parsing stdout')
     var config = {};
     String(stdout).split(os.EOL).forEach(function (line) {
         if (!line) {
@@ -70,7 +71,14 @@ function _parseStdout(stdout, namespace) {
     });
     config = objnest.expand(config);
     if (namespace) {
-        config = config[namespace];
+        var namespaceSplit = namespace.split('.')
+        if (namespaceSplit.length === 1) {
+            config = config[namespace];
+        } else {
+            namespaceSplit.forEach(function (namespace) {
+                config = config[namespace]
+            })
+        }
     }
     return config;
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -71,13 +71,10 @@ function _parseStdout(stdout, namespace) {
     config = objnest.expand(config);
     if (namespace) {
         var namespaceSplit = namespace.split('.')
-        if (namespaceSplit.length === 1) {
-            config = config[namespace];
-        } else {
-            namespaceSplit.forEach(function (namespace) {
-                config = config[namespace]
-            })
-        }
+
+        namespaceSplit.forEach(function (namespace) {
+            config = config[namespace]
+        })
     }
     return config;
 }


### PR DESCRIPTION
Passing the namespace as `user.email` would fail. Now the namespace is determined by recursively indenting the object based on the namespace's dot notation.
